### PR TITLE
Use HTTPS URLs for bukk.it

### DIFF
--- a/src/bukkit.coffee
+++ b/src/bukkit.coffee
@@ -23,7 +23,7 @@ Select     = require("soupselect").select
 HtmlParser = require "htmlparser"
 
 class Bukkit
-  url: "http://bukk.it/"
+  url: "https://bukk.it/"
   selector: "td a"
   regex: /bukkit me.*?([a-zA-Z0-9_\-\.]*)$/i
 


### PR DESCRIPTION
### Changes
* Use HTTPS URLs for bukk.it as it now 301s all HTTP requests

### Referenced Issues
* Closes https://github.com/scudco/hubot-bukkit/issues/2